### PR TITLE
Switch to the Eclipse sisu-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
               <pluginExecutions>
                 <pluginExecution>
                   <pluginExecutionFilter>
-                    <groupId>org.sonatype.plugins</groupId>
+                    <groupId>org.eclipse.sisu</groupId>
                     <artifactId>sisu-maven-plugin</artifactId>
-                    <versionRange>[1.1,)</versionRange>
+                    <versionRange>[0.3.4,)</versionRange>
                     <goals>
                       <goal>test-index</goal>
                       <goal>main-index</goal>
@@ -104,9 +104,9 @@
       </plugin>
 
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
+        <groupId>org.eclipse.sisu</groupId>
         <artifactId>sisu-maven-plugin</artifactId>
-        <version>1.1</version>
+        <version>0.3.4</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
plexus-cipher still uses the old Sonatype sisu plugin and could switch to the new Eclipse one.