### PR TITLE
Fix surefire warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,7 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <systemPropertyVariables>
-                <file.encoding>utf8</file.encoding>
-              </systemPropertyVariables>
+              <argLine>-Dfile.encoding=utf8</argLine>
             </configuration>
           </execution>
           <execution>
@@ -116,9 +114,7 @@
               <goal>test</goal>
             </goals>
             <configuration>
-              <systemPropertyVariables>
-                <file.encoding>iso8859-1</file.encoding>
-              </systemPropertyVariables>
+              <argLine>-Dfile.encoding=iso8859-1</argLine>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
As system property file.encoding should be set via argLine

Emitted warning:

```
[INFO] --- maven-surefire-plugin:2.22.2:test (iso8859-1) @ plexus-cipher ---
[WARNING] file.encoding cannot be set as system property, use <argLine>-Dfile.encoding=...</argLine> instead
```