### PR TITLE
Fixed insecure cryptography in PBECipher.java

### DIFF
--- a/src/test/java/org/sonatype/plexus/components/cipher/PBECipherTest.java
+++ b/src/test/java/org/sonatype/plexus/components/cipher/PBECipherTest.java
@@ -35,7 +35,7 @@ public class PBECipherTest
 
     String _cleatText = "veryOpenText";
 
-    String _encryptedText = "ibeHrdCOonkH7d7YnH7sarQLbwOk1ljkkM/z8hUhl4c=";
+    String _encryptedText = "F7eMV2QRQF4H0ODCA1nrTGUWacCXVvPemSjaQjGbO6U=";
 
     String _password = "testtest";
 


### PR DESCRIPTION
By default (with the default constants and settings) the DefaultPlexusCipher object takes a plaintext and a human-readable password that I will refer to as “pwd”. It then generates a key and an IV to be used with AES/CBC/PKCS5Padding. The encrypt64 method generates a random 8 byte salt, computes SHA256(pwd|salt), and then uses the first 16 bytes of the hash as the AES key and the last 16 bytes of the hash as the IV. The salt is then prepended to the ciphertext and the result is base64 encoded and outputted.
 
This key derivation algorithm is extremely insecure and ciphertexts produced by plexus-cipher are currently easy to brute force. SHA256 is meant to be fast. During a brute force attempt, identifying the correct key and IV is fairly easy: the correct key and IV will yield a decryption with significantly less Shannon entropy than all of the failed decryption attempts, which will produce outputs indistinguishable from random bytes (which will have high Shannon entropy). Data that needs to be encrypted tends to have some sort of structure, and is often times composed of ASCII characters.

An ideal fix here is to just use a well-established key derivation function such as PBKDF2 (as I have done). OWASP recommends to use 310000+ iterations with PBKDF2.

https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html

**This fix is not backwards compatible** and will will cause people using Plexus Cipher to have to re-encrypt their information. The existing cryptography provides little protection in its current state though. 